### PR TITLE
microshift: add default gateway config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+---
 receivers:
   otlp:
     protocols:
@@ -21,12 +22,10 @@ receivers:
       disk:
       filesystem:
 
-
 processors:
   batch:
   resourcedetection/system:
     detectors: ["system"]
-
 
 exporters:
   debug:

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - opentelemetry-gateway.yaml

--- a/opentelemetry-collector-rhde-config.spec
+++ b/opentelemetry-collector-rhde-config.spec
@@ -1,12 +1,14 @@
 Name: opentelemetry-collector-rhde-config
 Version: 1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: RHDE Observability Agent
 BuildArch: noarch
 
 License: Apache-2.0
 Source1: config.yaml
 Source2: opentelemetry-collector-rhde-config.service
+Source3: opentelemetry-gateway.yaml
+Source4: kustomization.yaml
 
 # Necessary to access the systemd macros
 BuildRequires: systemd
@@ -26,6 +28,8 @@ mkdir -p %{buildroot}%{_unitdir}
 # install files
 install -p -m 0644 -D %{SOURCE1} %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config/config.yaml
 install -p -m 0644 -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
+install -p -m 0644 -D %{SOURCE3} %{buildroot}%{_sysconfdir}/microshift/manifests/opentelemetry-gateway.yaml
+install -p -m 0644 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/microshift/manifests/kustomization.yaml
 
 # TODO give access to microshift logs
 # TODO give access to proc for metrics
@@ -54,7 +58,11 @@ fi
 %files
 %{_unitdir}/%{name}.service
 %{_sysconfdir}/opentelemetry-collector-rhde-config/config.yaml
+%{_sysconfdir}/microshift/manifests/opentelemetry-gateway.yaml
+%{_sysconfdir}/microshift/manifests/kustomization.yaml
 
 %changelog
+* Fri Apr 12 2024 Benedikt Bongartz <bongartz@redhat.com> - 1.0-2
+- add microshift manifests
 * Fri Jan 26 2024 Benedikt Bongartz <bongartz@redhat.com> - 1.0-1
 - initialize package

--- a/opentelemetry-gateway.yaml
+++ b/opentelemetry-gateway.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-gateway-config
+  namespace: observability
+data:
+  # TODO: add k8s/microshift specific configuration
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    exporters:
+      otlp/host:
+        endpoint: localhost:4317
+        tls:
+          insecure: true
+          insecure_skip_verify: true
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/host]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/host]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/host]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-gateway
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hostnetwork-v2-scc-opentelemetry-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:hostnetwork-v2
+subjects:
+- kind: ServiceAccount
+  name: opentelemetry-gateway
+  namespace: observability
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: opentelemetry-gateway
+  namespace: observability
+  labels:
+    app: opentelemetry-gateway
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry-gateway
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-gateway
+    spec:
+      # NOTE: Use port 54317 and 54318 to avoid a conflict with the collector on the host.
+      serviceAccount: opentelemetry-gateway
+      serviceAccountName: opentelemetry-gateway
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - name: opentelemetry-collector
+        image: registry.redhat.io/rhosdt/opentelemetry-collector-rhel8:0.93.0
+        command: ["/go/bin/otelcol-linux", "--config=/etc/opentelemetry/config.yaml"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/opentelemetry
+      volumes:
+      - name: config-volume
+        configMap:
+          name: opentelemetry-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: observability
+spec:
+  ports:
+    - name: http-otlp
+      port: 4318
+      targetPort: 54318
+      protocol: TCP
+    - name: grpc-otlp
+      port: 4317
+      targetPort: 54317
+      protocol: TCP
+  selector:
+    app: opentelemetry-gateway


### PR DESCRIPTION
Minimal MicroShift version needed is `4.14`.

Config was tested on rhel 9:
```
$ microshift version
MicroShift Version: 4.14.20
Base OCP Version: 4.14.20
```

Build:
https://copr.fedorainfracloud.org/coprs/miyunari/redhat-opentelemetry-collector/build/7304114/

Closes #2 