### PR TITLE
Add host collector configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,3 +20,16 @@ fedpkg --release f37 mockbuild
 ```
 
 Then upload the source RPM into Copr and build it there.
+
+Install and uninstall: 
+```bash
+sudo rpm -i opentelemetry-collector-rhde-config-1.0-1.fc39.noarch.rpm 
+sudo dnf remove opentelemetry-collector-rhde-config.noarch
+```
+
+List and start systemd service
+```bash
+sudo systemctl list-unit-files --all | grep opentelemetry
+sudo systemctl start opentelemetry-collector-rhde-config.service
+journalctl -u opentelemetry-collector-rhde-config.service
+```

--- a/config.yaml
+++ b/config.yaml
@@ -1,155 +1,43 @@
----
 receivers:
-  journald:
-    units:
-      - sshd # Example unit, more can be added
-    priority: info
-  filelog:
-    include:
-      - /var/log/pods/*/*/*.log
-    exclude:
-      # Exclude logs from all containers named otel-collector
-      - /var/log/pods/*/otel-collector/*.log
-    start_at: beginning
-    include_file_path: true
-    include_file_name: false
-    operators:
-      # Find out which format is used by kubernetes
-      - type: router
-        id: get-format
-        routes:
-          - output: parser-docker
-            expr: 'body matches "^\\{"'
-          - output: parser-crio
-            expr: 'body matches "^[^ Z]+ "'
-          - output: parser-containerd
-            expr: 'body matches "^[^ Z]+Z"'
-      # Parse CRI-O format
-      - type: regex_parser
-        id: parser-crio
-        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout_type: gotime
-          layout: '2006-01-02T15:04:05.999999999Z07:00'
-      # Parse CRI-Containerd format
-      - type: regex_parser
-        id: parser-containerd
-        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-      # Parse Docker format
-      - type: json_parser
-        id: parser-docker
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-      - type: move
-        from: attributes.log
-        to: body
-      # Extract metadata from file path
-      - type: regex_parser
-        id: extract_metadata_from_filepath
-        regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-        parse_from: attributes["log.file.path"]
-      # Rename attributes
-      - type: move
-        from: attributes.stream
-        to: attributes["log.iostream"]
-      - type: move
-        from: attributes.container_name
-        to: resource["k8s.container.name"]
-      - type: move
-        from: attributes.namespace
-        to: resource["k8s.namespace.name"]
-      - type: move
-        from: attributes.pod_name
-        to: resource["k8s.pod.name"]
-      - type: move
-        from: attributes.restart_count
-        to: resource["k8s.container.restart_count"]
-      - type: move
-        from: attributes.uid
-        to: resource["k8s.pod.uid"]
-  otlp/workload:
+  otlp:
     protocols:
       grpc:
       http:
-  k8s_cluster:
-    auth_type: kubeConfig
-    distribution: openshift
-    collection_interval: 10s
-    node_conditions_to_report: [Ready, MemoryPressure]
-    allocatable_types_to_report: [cpu, memory]
-  k8s_events:
-    auth_type: kubeConfig
+
+  journald:
+    units:
+    priority: info
+
   hostmetrics:
-    root_path: /hostfs
+    root_path: /
     collection_interval: 10s
     scrapers:
       cpu:
       memory:
   hostmetrics/disk:
-    root_path: /hostfs
+    root_path: /
     collection_interval: 30s
     scrapers:
       disk:
       filesystem:
+
+
 processors:
+  batch:
   resourcedetection/system:
     detectors: ["system"]
-  batch:
-  attributes/k8s:
-    actions:
-     - action: insert
-       key: log_file_name
-       from_attribute: log.file.name
-     - action: insert
-       key: loki.attribute.labels
-       value: log_file_name
 
-connectors:
-  forward/logs:
-  forward/metrics:
 
 exporters:
   debug:
 
 service:
   pipelines:
-    metrics/workload:
-      receivers: [otlp/workload, hostmetrics, hostmetrics/disk]
-      exporters: [forward/metrics]
-    metrics/k8s:
-      receivers: [k8s_cluster]
-      exporters: [forward/metrics]
-    logs/workload:
-      receivers: [otlp/workload]
-      exporters: [forward/logs]
-    logs/k8s_events:
-      receivers: [k8s_cluster, k8s_events]
-      exporters: [forward/logs]
-    logs/k8s:
-      receivers: [filelog]
-      processors: [attributes/k8s]
-      exporters: [forward/logs]
-    logs/journald:
-      receivers: [journald]
-      exporters: [forward/logs]
-
-    traces/workload:
-      receivers: [otlp/workload]
+    metrics:
+      receivers: [otlp, hostmetrics, hostmetrics/disk]
       processors: [resourcedetection/system, batch]
       exporters: [debug]
-    log/forward:
-      receivers: [forward/logs]
-      processors: [resourcedetection/system, batch]
-      exporters: [debug]
-    metric/forward:
-      receivers: [forward/metrics]
+    logs:
+      receivers: [otlp, journald]
       processors: [resourcedetection/system, batch]
       exporters: [debug]

--- a/opentelemetry-collector-rhde-config.spec
+++ b/opentelemetry-collector-rhde-config.spec
@@ -12,6 +12,9 @@ Source2: opentelemetry-collector-rhde-config.service
 BuildRequires: systemd
 Requires: opentelemetry-collector
 
+Requires(pre): /usr/sbin/useradd, /usr/bin/getent
+Requires(postun): /usr/sbin/userdel
+
 %description
 RHDE observability agent configuration.
 
@@ -28,6 +31,13 @@ mkdir -p %{buildroot}%{_unitdir}
 # TODO what is the directory where to install the service
 install -p -m 0644 -D %{SOURCE1} %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config/config.yaml
 install -p -m 0644 -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
+
+%pre
+/usr/bin/getent group rhde-observability > /dev/null || /usr/sbin/groupadd -r rhde-observability
+/usr/bin/getent passwd rhde-observability > /dev/null || /usr/sbin/useradd -r -d /path/to/program -s /sbin/nologin -g rhde-observability rhde-observability
+
+%postun
+/usr/sbin/userdel rhde-observability
 
 %post
 /bin/systemctl --system daemon-reload 2>&1

--- a/opentelemetry-collector-rhde-config.spec
+++ b/opentelemetry-collector-rhde-config.spec
@@ -22,16 +22,13 @@ RHDE observability agent configuration.
 # create expected directory layout
 mkdir -p %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config
 mkdir -p %{buildroot}%{_unitdir}
-# TODO install default user for the collector and grant permission. Have access to systemd logs.
-# TODO have access to microshift logs.
-# TODO have access to proc for metrics.
 
 # install files
-# TODO install collector k8s service in the microshift folder
-# TODO what is the directory where to install the service
 install -p -m 0644 -D %{SOURCE1} %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config/config.yaml
 install -p -m 0644 -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 
+# TODO give access to microshift logs
+# TODO give access to proc for metrics
 %pre
 /usr/bin/getent group rhde-observability > /dev/null || /usr/sbin/groupadd -r rhde-observability
 /usr/bin/getent passwd rhde-observability > /dev/null || /usr/sbin/useradd -r -d /path/to/program -s /sbin/nologin -g rhde-observability rhde-observability


### PR DESCRIPTION
I have tested this locally on my f37 machine:

```bash
Apr 10 15:03:53 fedora systemd[1]: Started opentelemetry-collector-rhde-config.service - RHDE Observability Agent.
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.553+0200        info        service/telemetry.go:55        Setting up own telemetry...
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.554+0200        info        service/telemetry.go:97        Serving metrics        {"address": ":8888", "level": "Basic"}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.554+0200        info        exporter/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "metrics", "name": "debug"}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.556+0200        info        exporter/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "logs", "name": "debug"}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.563+0200        info        service/service.go:143        Starting otelcol...        {"Version": "0.95.0", "NumCPU": 12}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.563+0200        info        extensions/extensions.go:34        Starting extensions...
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.565+0200        info        internal/resourcedetection.go:125        began detecting resource information        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics"}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.713+0200        info        system/system.go:201        This attribute changed from int to string. Temporarily switch back to int using the feature gate.        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "attribute": "host.cpu.family", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsStrin>
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.714+0200        info        system/system.go:220        This attribute changed from int to string. Temporarily switch back to int using the feature gate.        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "attribute": "host.cpu.model.id", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsStr>
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.714+0200        info        internal/resourcedetection.go:139        detected resource information        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "resource": {"host.name":"fedora","os.type":"linux"}}
Apr 10 15:03:53 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:53.714+0200        info        adapter/receiver.go:45        Starting stanza receiver        {"kind": "receiver", "name": "journald", "data_type": "logs"}
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.715+0200        warn        internal/warning.go:42        Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks. Enable the feature gate to change the default and remove this warning.        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://gi>
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.721+0200        info        otlpreceiver/otlp.go:102        Starting GRPC server        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4317"}
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.723+0200        warn        internal/warning.go:42        Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks. Enable the feature gate to change the default and remove this warning.        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://gi>
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.724+0200        info        otlpreceiver/otlp.go:152        Starting HTTP server        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4318"}
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.724+0200        info        service/service.go:169        Everything is ready. Begin running and processing data.
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.724+0200        warn        localhostgate/featuregate.go:63        The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.        {"feature gate ID": "component.UseLocalHostAsDefaultHost"}
Apr 10 15:03:54 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:54.766+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 10}
Apr 10 15:03:55 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:55.168+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 10}
Apr 10 15:03:55 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:55.766+0200        info        MetricsExporter        {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 4, "metrics": 11, "data points": 194}
Apr 10 15:03:55 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:55.770+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 3}
Apr 10 15:03:56 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:56.172+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 2}
Apr 10 15:03:56 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:56.775+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:03:57 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:57.177+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:03:57 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:57.779+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:03:58 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:58.180+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:03:58 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:58.783+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:03:59 fedora opentelemetry-collector[183549]: 2024-04-10T15:03:59.184+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 10 15:04:05 fedora opentelemetry-collector[183549]: 2024-04-10T15:04:05.807+0200        info        MetricsExporter        {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 2, "metrics": 2, "data points": 102}

```