### PR TITLE
Use specific user to run the systemd service

### DIFF
--- a/opentelemetry-collector-rhde-config.service
+++ b/opentelemetry-collector-rhde-config.service
@@ -5,6 +5,8 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/opentelemetry-collector --config /etc/opentelemetry-collector-rhde-config/config.yaml
+User=rhde-observability
+Group=rhde-observability
 Restart=on-failure
 RestartSec=30
 

--- a/opentelemetry-collector-rhde-config.spec
+++ b/opentelemetry-collector-rhde-config.spec
@@ -31,7 +31,7 @@ install -p -m 0644 -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 # TODO give access to proc for metrics
 %pre
 /usr/bin/getent group rhde-observability > /dev/null || /usr/sbin/groupadd -r rhde-observability
-/usr/bin/getent passwd rhde-observability > /dev/null || /usr/sbin/useradd -r -d /path/to/program -s /sbin/nologin -g rhde-observability rhde-observability
+/usr/bin/getent passwd rhde-observability > /dev/null || /usr/sbin/useradd -r -M -s /sbin/nologin -g rhde-observability -G systemd-journal rhde-observability
 
 %postun
 /usr/sbin/userdel rhde-observability


### PR DESCRIPTION
Passed build: https://copr.fedorainfracloud.org/coprs/miyunari/redhat-opentelemetry-collector/build/7296250/

Resolves: #1 


```
ps -ef | grep opentelemetry                                                                                                                                                                                                                                                                                                                                                                                rhde-ob+  272042       1  0 12:02 ?        00:00:00 /usr/bin/opentelemetry-collector --config /etc/opentelemetry-collector-rhde-config/config.yaml

 cat /etc/group | grep rhde                                                                                                                                                                                                                                                                                                                  ploffay@fedora
systemd-journal:x:190:rhde-observability
rhde-observability:x:975:


cat /etc/passwd | grep rhde                                                                                                                                                                                                                                                                                                                 ploffay@fedora
rhde-observability:x:974:975::/home/rhde-observability:/sbin/nologin
```

Logs
```
Apr 11 12:02:49 fedora systemd[1]: Started opentelemetry-collector-rhde-config.service - RHDE Observability Agent.
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.331+0200        info        service/telemetry.go:55        Setting up own telemetry...
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.332+0200        info        service/telemetry.go:97        Serving metrics        {"address": ":8888", "level": "Basic"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.332+0200        info        exporter/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "logs", "name": "debug"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.333+0200        info        exporter/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "metrics", "name": "debug"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.335+0200        info        service/service.go:143        Starting otelcol...        {"Version": "0.95.0", "NumCPU": 12}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.335+0200        info        extensions/extensions.go:34        Starting extensions...
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.335+0200        info        internal/resourcedetection.go:125        began detecting resource information        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "logs"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        info        system/system.go:201        This attribute changed from int to string. Temporarily switch back to int using the feature gate.        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "logs", "attribute": "host.cpu.family", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsString"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        info        system/system.go:220        This attribute changed from int to string. Temporarily switch back to int using the feature gate.        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "logs", "attribute": "host.cpu.model.id", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsString>
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        info        internal/resourcedetection.go:139        detected resource information        {"kind": "processor", "name": "resourcedetection/system", "pipeline": "logs", "resource": {"host.name":"fedora","os.type":"linux"}}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        warn        internal/warning.go:42        Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks. Enable the feature gate to change the default and remove this warning.        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://gi>
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        info        otlpreceiver/otlp.go:102        Starting GRPC server        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4317"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.342+0200        warn        internal/warning.go:42        Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks. Enable the feature gate to change the default and remove this warning.        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://gi>
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.343+0200        info        otlpreceiver/otlp.go:152        Starting HTTP server        {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4318"}
Apr 11 12:02:49 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:49.343+0200        info        adapter/receiver.go:45        Starting stanza receiver        {"kind": "receiver", "name": "journald", "data_type": "logs"}
Apr 11 12:02:50 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:50.343+0200        info        service/service.go:169        Everything is ready. Begin running and processing data.
Apr 11 12:02:50 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:50.343+0200        warn        localhostgate/featuregate.go:63        The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.        {"feature gate ID": "component.UseLocalHostAsDefaultHost"}
Apr 11 12:02:50 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:50.537+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 10}
Apr 11 12:02:50 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:50.938+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 3}
Apr 11 12:02:51 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:51.541+0200        info        LogsExporter        {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
Apr 11 12:02:51 fedora opentelemetry-collector[272042]: 2024-04-11T12:02:51.541+0200        info        MetricsExporter        {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 4, "metrics": 11, "data points": 194}

```
