### PR TITLE
collector: support merging multiple configurations

### DIFF
--- a/opentelemetry-collector-rhde-config.service
+++ b/opentelemetry-collector-rhde-config.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/opentelemetry-collector --config /etc/opentelemetry-collector-rhde-config/config.yaml
+ExecStart=/usr/bin/opentelemetry-collector-with-options
 User=rhde-observability
 Group=rhde-observability
 Restart=on-failure
@@ -12,5 +12,3 @@ RestartSec=30
 
 [Install]
 WantedBy=multi-user.target
-
-# TODO run this service with a user that is defined in the .spec file

--- a/opentelemetry-collector-rhde-config.spec
+++ b/opentelemetry-collector-rhde-config.spec
@@ -1,6 +1,6 @@
 Name: opentelemetry-collector-rhde-config
 Version: 1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: RHDE Observability Agent
 BuildArch: noarch
 
@@ -9,6 +9,7 @@ Source1: config.yaml
 Source2: opentelemetry-collector-rhde-config.service
 Source3: opentelemetry-gateway.yaml
 Source4: kustomization.yaml
+Source5: opentelemetry-collector-with-options
 
 # Necessary to access the systemd macros
 BuildRequires: systemd
@@ -23,6 +24,7 @@ RHDE observability agent configuration.
 %install
 # create expected directory layout
 mkdir -p %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config
+mkdir -p %{buildroot}%{_sysconfdir}/opentelemetry-collector-rhde-config/patch
 mkdir -p %{buildroot}%{_unitdir}
 
 # install files
@@ -30,6 +32,7 @@ install -p -m 0644 -D %{SOURCE1} %{buildroot}%{_sysconfdir}/opentelemetry-collec
 install -p -m 0644 -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
 install -p -m 0644 -D %{SOURCE3} %{buildroot}%{_sysconfdir}/microshift/manifests/opentelemetry-gateway.yaml
 install -p -m 0644 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/microshift/manifests/kustomization.yaml
+install -p -m 0755 -D %{SOURCE5} %{buildroot}%{_bindir}/opentelemetry-collector-with-options
 
 # TODO give access to microshift logs
 # TODO give access to proc for metrics
@@ -60,8 +63,11 @@ fi
 %{_sysconfdir}/opentelemetry-collector-rhde-config/config.yaml
 %{_sysconfdir}/microshift/manifests/opentelemetry-gateway.yaml
 %{_sysconfdir}/microshift/manifests/kustomization.yaml
+%{_bindir}/opentelemetry-collector-with-options
 
 %changelog
+* Thu Apr 18 2024 Benedikt Bongartz <bongartz@redhat.com> - 1.0-3
+- support opentelemetry configuration merge
 * Fri Apr 12 2024 Benedikt Bongartz <bongartz@redhat.com> - 1.0-2
 - add microshift manifests
 * Fri Jan 26 2024 Benedikt Bongartz <bongartz@redhat.com> - 1.0-1

--- a/opentelemetry-collector-with-options
+++ b/opentelemetry-collector-with-options
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MAIN_CONFIG="/etc/opentelemetry-collector-rhde-config/config.yaml"
+PATCH_DIR="/etc/opentelemetry-collector-rhde-config/patch/"
+
+if [ -d "$PATCH_DIR" ]; then
+    PATCH_FILES=$(ls "$PATCH_DIR"/*.yaml 2>/dev/null | sort)
+    if [ -n "$PATCH_FILES" ]; then
+        CONFIG_OPTIONS=""
+
+        for PATCH_FILE in $PATCH_FILES; do
+            CONFIG_OPTIONS+=" --config \"file:$PATCH_FILE\""
+        done
+    fi
+fi
+
+/usr/bin/opentelemetry-collector --config "file:$MAIN_CONFIG"$CONFIG_OPTIONS


### PR DESCRIPTION
It still needs some manual testing.

@fkolwa @miyunari should we consider moving the entire pkg config into the `opentelemetry-collector.rpm`? In that case the  `opentelemetry-collector-config-awscloudwatch.rpm` just needs to drop the exporter config in `/etc/opentelemetry-collector-rhde-config/patch/00-cloudwatch-expoter.yaml`. While we could rename the config path to `/etc/opentelemetry-collector/...`. wdyt? 

cc @mparram 